### PR TITLE
Fix: user styles not respected

### DIFF
--- a/lib/ActionSheetCustom.js
+++ b/lib/ActionSheetCustom.js
@@ -167,7 +167,7 @@ class ActionSheet extends Component {
     } = this.props;
 
     const { visible, sheetPositionY } = this.state;
-    const styles = Object.assign({}, userStyles, defaultStyles);
+    const styles = Object.assign({}, defaultStyles, userStyles);
 
     return (
       <Modal


### PR DESCRIPTION
User styles are not respected because of this line of code:
`const styles = Object.assign({}, userStyles, defaultStyles);`

`defaultStyles` takes precedence over `userStyles`. I've switched their places in order to allow for user-specific styles. 